### PR TITLE
Ensure the way to import comScore into projects is consistent

### DIFF
--- a/ComScore-iOS.podspec
+++ b/ComScore-iOS.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.vendored_libraries = 'comScore/libcomScore.a'
   s.frameworks = 'SystemConfiguration', 'Security'
   s.module_map = 'comScore/ComScore.modulemap'
+  s.header_dir = 'ComScore'
   s.module_name = 'ComScore'
   s.xcconfig = { 'OTHER_LDFLAGS' => '-ObjC' }
 end


### PR DESCRIPTION
## Problem

When using comScore as a project CocoaPods dependency, the way to import the library differs depending on whether frameworks are used (`use_frameworks!` Podfile setting) or not.

### Without use_frameworks!

If `use_frameworks!` is not enabled, the framework name is automatically derived from the podspec name. comScore imports are therefore done as follows from Objective-C code or from a bridging header:

    #import <ComScore-iOS/ComScore.h>

### With use_frameworks!

If `use_frameworks!` is enabled, the framework name is derived from the module name. comScore imports are done as follows from Objective-C code or from a bridging header:

    #import <ComScore/ComScore.h>

If modules imports have been enabled, they are done as follows in Objective-C:

    @import ComScore;

or in Swift:

    import ComScore

## Solution

To avoid this inconsistency, which is annoying when comScore is itself a dependency of a library meant to be integrated with CocoaPods (in Objective-C or Swift projects), the `header_dir` podspec setting should be overridden using the same name as the module (the name itself is good since it is C99 compliant, unlike `ComScore-iOS` which contains a hyphen).

This way, the comScore library is always consistently imported as follows from Objective-C code or bridging headers:

    #import <ComScore/ComScore.h>

with modules in Objective-C:

    @import ComScore;

and in Swift:

    import ComScore

Thanks in advance for having a look at this pull request.

Best regards.